### PR TITLE
add detail page for books

### DIFF
--- a/pages/[key].js
+++ b/pages/[key].js
@@ -50,16 +50,15 @@ export default function DetailPage({
         <p>{currentBook.author_name}</p>
         <h4>{currentBook.title}</h4>
         <p>(first published: {currentBook.first_publish_year})</p>
-        <p className="description">
+        <article className="description">
           {!description && "no description available"}
           {description?.value ? description.value : description}
-        </p>
+        </article>
       </BookDetails>
     </Main>
   );
 }
 const Main = styled.main`
-  position: relative;
   display: flex;
   justify-content: center;
 `;
@@ -76,22 +75,33 @@ const StyledImage = styled(Image)`
 
 const BookDetails = styled.article`
   position: fixed;
-  max-width: 700px;
   top: 70%;
-  margin: 0 1.5rem 0 1.5rem;
+  width: 90vw;
+  max-width: 700px;
   padding: 0.5rem;
   background-color: rgba(255, 255, 255, 0.5);
 
-  @media (max-width: 768px) {
-    .description {
-      font-size: 0.77rem;
+  .description {
+    overflow-y: scroll;
+    ::-webkit-scrollbar {
+      width: 0.5rem;
+      height: 1em;
+      background-color: darkgrey;
     }
   }
 
-  @media (min-width: 769px) {
-    font-size: 1.5rem;
+  @media (max-width: 799px) {
+    .description {
+      font-size: 0.77rem;
+      height: 15vh;
+    }
+  }
+
+  @media (min-width: 800px) {
+    font-size: 1.25rem;
     .description {
       font-size: 1rem;
+      height: 10vh;
     }
   }
 `;

--- a/pages/[key].js
+++ b/pages/[key].js
@@ -1,0 +1,97 @@
+import styled from "styled-components";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import Image from "next/image";
+
+export default function DetailPage({
+  searchedBooks,
+  description,
+  onUpdateDescription,
+}) {
+  const router = useRouter();
+  const { key } = router.query;
+
+  if (!searchedBooks) {
+    return null;
+  }
+  const currentBook = searchedBooks.docs?.find(
+    (book) => book.key.split("/")[2] === key
+  );
+
+  if (!currentBook) {
+    return null;
+  }
+
+  async function getDescription() {
+    const response = await fetch(`https://openlibrary.org/works/${key}.json`);
+    const matchedBook = await response.json();
+    const currentDescription = matchedBook.description;
+    onUpdateDescription(currentDescription);
+  }
+
+  useEffect(() => {
+    getDescription();
+  }, []);
+
+  return (
+    <Main>
+      <ImageContainer>
+        <StyledImage
+          src={
+            Array.isArray(currentBook.isbn)
+              ? `https://covers.openlibrary.org/b/isbn/${currentBook.isbn[0]}-L.jpg`
+              : `https://covers.openlibrary.org/b/isbn/${currentBook.isbn}-L.jpg`
+          }
+          fill
+          alt={`cover image of ${currentBook.title}`}
+        />
+      </ImageContainer>
+      <BookDetails>
+        <p>{currentBook.author_name}</p>
+        <h4>{currentBook.title}</h4>
+        <p>(first published: {currentBook.first_publish_year})</p>
+        <p className="description">
+          {!description && "no description available"}
+          {description?.value ? description.value : description}
+        </p>
+      </BookDetails>
+    </Main>
+  );
+}
+const Main = styled.main`
+  position: relative;
+  display: flex;
+  justify-content: center;
+`;
+const ImageContainer = styled.div`
+  position: relative;
+  width: 100vw;
+  height: 160vw;
+`;
+
+const StyledImage = styled(Image)`
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
+  z-index: -1;
+`;
+
+const BookDetails = styled.article`
+  position: fixed;
+  max-width: 700px;
+  top: 70%;
+  margin: 0 1.5rem 0 1.5rem;
+  padding: 0.5rem;
+  background-color: rgba(255, 255, 255, 0.5);
+
+  @media (max-width: 768px) {
+    .description {
+      font-size: 0.77rem;
+    }
+  }
+
+  @media (min-width: 769px) {
+    font-size: 1.5rem;
+    .description {
+      font-size: 1rem;
+    }
+  }
+`;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,6 +5,7 @@ import GlobalStyles from "@/components/GlobalStyles";
 export default function App({ Component, pageProps }) {
   const [searchedBooks, setSearchedBooks] = useState([]);
   const [currentSearchTerm, setCurrentSearchTerm] = useState("");
+  const [description, setDescription] = useState("");
 
   function handleUpdateSearchedBooks(newBooks) {
     setSearchedBooks(newBooks);
@@ -14,6 +15,9 @@ export default function App({ Component, pageProps }) {
     setCurrentSearchTerm(searchTerm);
   }
 
+  function handleUpdateDescription(description) {
+    setDescription(description);
+  }
   return (
     <>
       <Head>
@@ -27,6 +31,8 @@ export default function App({ Component, pageProps }) {
         searchedBooks={searchedBooks}
         onUpdateCurrentSearchTerm={handleUpdateCurrentSearchTerm}
         currentSearchTerm={currentSearchTerm}
+        onUpdateDescription={handleUpdateDescription}
+        description={description}
       />
     </>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,7 @@
 import Head from "next/head";
 import styled from "styled-components";
 import Image from "next/image";
+import Link from "next/link";
 
 export default function Home({
   onUpdateSearchedBooks,
@@ -50,20 +51,22 @@ export default function Home({
           </CurrentSearchTerm>
         )}
         {searchedBooks.docs?.map((book) => (
-          <SearchResult key={book.key}>
-            <Author>author: {book.author_name}</Author>
-            <Title>title: {book.title}</Title>
-            <StyledImage
-              src={
-                Array.isArray(book.isbn)
-                  ? `https://covers.openlibrary.org/b/isbn/${book.isbn[0]}-S.jpg`
-                  : `https://covers.openlibrary.org/b/isbn/${book.isbn}-S.jpg`
-              }
-              width={50}
-              height={80}
-              alt={`cover image of ${book.title}`}
-            />
-          </SearchResult>
+          <StyledLink href={`/${book.key.split("/")[2]}`} key={book.key}>
+            <SearchResult>
+              <Author>author: {book.author_name}</Author>
+              <Title>title: {book.title}</Title>
+              <StyledImage
+                src={
+                  Array.isArray(book.isbn)
+                    ? `https://covers.openlibrary.org/b/isbn/${book.isbn[0]}-S.jpg`
+                    : `https://covers.openlibrary.org/b/isbn/${book.isbn}-S.jpg`
+                }
+                width={50}
+                height={80}
+                alt={`cover image of ${book.title}`}
+              />
+            </SearchResult>
+          </StyledLink>
         ))}
       </main>
     </>
@@ -135,4 +138,9 @@ const StyledHeading = styled.header`
   font-size: 2rem;
   border-bottom-left-radius: 10px;
   border-bottom-right-radius: 10px;
+`;
+
+const StyledLink = styled(Link)`
+  text-decoration: none;
+  color: black;
 `;


### PR DESCRIPTION
* add a detail page for each book from the search results
* each search result is a link that takes the user to a dynamic page for each book
* the cover image is displayed in the background and fades to the bottom
* the author, title and publication date are displayed from the original object returned by submitting the search
* the description is fetched from a [detail API](https://openlibrary.org/dev/docs/api/books)
* design is responsive for smartphone and larger screens e.g. tablet/monitor